### PR TITLE
Delayed Job support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -5,7 +5,11 @@ Important: Needs Fat Free Crm >= 0.9.10
 
 Put/Edit/Delete events for tasks with due date
 
-This plugin needs http://github.com/tractis/crm_google_account_settings plugin to work, google account settings in user profile
+This plugin requires:
+
+ * https://github.com/tractis/crm_google_account_settings - google account settings in user profile
+ * https://github.com/collectiveidea/delayed_job - Delayed job (v2.0) for responsiveness
+
 
 Installation
 ============
@@ -14,7 +18,15 @@ The plugin can be installed by running:
 
     script/plugin install git://github.com/tractis/crm_google_account_settings.git
     script/plugin install git://github.com/tractis/crm_google_calendar.git
+	script/plugin install git://github.com/collectiveidea/delayed_job.git -r v2.0
     sudo gem install gcal4ruby
+	script/generate delayed_job
+	rake db:migrate
+
+Choose how to run the delayed_jobs script:
+
+ * Using god: http://jetpackweb.com/blog/tags/delayed_job/
+ * Using monit: http://stackoverflow.com/questions/1226302/how-to-monitor-delayed-job-with-monit
 
 Then restart your web server.
 

--- a/README.markdown
+++ b/README.markdown
@@ -16,12 +16,13 @@ Installation
 
 The plugin can be installed by running:
 
-    script/plugin install git://github.com/tractis/crm_google_account_settings.git
-    script/plugin install git://github.com/tractis/crm_google_calendar.git
+	script/plugin install git://github.com/tractis/crm_google_account_settings.git
+	script/plugin install git://github.com/tractis/crm_google_calendar.git
 	script/plugin install git://github.com/collectiveidea/delayed_job.git -r v2.0
-    sudo gem install gcal4ruby
+	sudo gem install gcal4ruby
 	script/generate delayed_job
 	rake db:migrate
+	rake db:migrate:plugin NAME=crm_google_calendar
 
 Choose how to run the delayed_jobs script:
 

--- a/db/migrate/2011013_add_g_cal_event_id_to_task.rb
+++ b/db/migrate/2011013_add_g_cal_event_id_to_task.rb
@@ -1,0 +1,9 @@
+class AddGCalEventIdToTask < ActiveRecord::Migration
+  def self.up
+    add_column :tasks, :gcal_event_id, :string
+  end
+
+  def self.down
+    remove_column :tasks, :gcal_event_id
+  end
+end

--- a/init.rb
+++ b/init.rb
@@ -5,7 +5,7 @@ FatFreeCRM::Plugin.register(:crm_google_calendar, initializer) do
        authors "Tractis - https://www.tractis.com - Jose Luis Gordo Romero"
        version "0.1"
    description "Create events from tasks in your google calendar"
-  dependencies :haml, :simple_column_search
+  dependencies :haml, :simple_column_search, :delayed_job
 end
 
 require "crm_google_calendar"

--- a/lib/crm_google_calendar/crm_google_calendar_model_hooks.rb
+++ b/lib/crm_google_calendar/crm_google_calendar_model_hooks.rb
@@ -1,134 +1,71 @@
-class TaskNotAllowedError < StandardError; end
 
-def get_calendar(user_id)
-  current_user = User.find(user_id)
-  service = GCal4Ruby::Service.new
-  begin
-    service.authenticate(current_user.pref[:google_account], current_user.pref[:google_password])
-  rescue GData4Ruby::HTTPRequestFailed => ex
-    return false
+class EventJob < Struct.new(:user_id, :options, :previous)
+  def get_calendar
+    current_user = User.find(user_id)
+    service = GCal4Ruby::Service.new
+    begin
+      service.authenticate(current_user.pref[:google_account], current_user.pref[:google_password])
+    rescue GData4Ruby::HTTPRequestFailed => ex
+      return false
+    end
+    service.calendars.first
   end
-  service.calendars.first
+
+  def merge(event, options)
+    options.each do |key, value|
+      event.send "#{key}=", value
+    end
+  end
 end
 
-class CreateEventJob < Struct.new(:user_id, :options)
+class CreateEventJob < EventJob
   def perform
-    require "pp"
-    if cal = get_calendar(user_id)
+    if cal = get_calendar
       event = GCal4Ruby::Event.new(cal.service, {:calendar => cal})
-      event.title = options[:title]
-      event.content = options[:content] || ''
-      event.attendees = options[:attendees]
-      event.start_time = options[:start_time]
-      event.end_time = options[:end_time]
-      event.all_day = options[:all_day]
-      event.reminder = options[:reminder]
+      merge event, options
       event.save
     end
   end
 end
 
-class UpdateEventJob < Struct.new(:user_id, :title, :options)
+class UpdateEventJob < EventJob
   def perform
-    if cal = get_calendar(user_id)
-      event = GCal4Ruby::Event.find(cal.service, title, {:calendar => cal.id}).first
+    if cal = get_calendar
+      event = GCal4Ruby::Event.find(cal.service, previous, {:calendar => cal.id}).first
       unless event.blank?
-        event.title = options[:title]
-        event.content = options[:content] || ''
-        event.attendees = options[:attendees]
-        event.start_time = options[:start_time]
-        event.end_time = options[:end_time]
-        event.all_day = options[:all_day]
-        event.reminder = options[:reminder]
+        merge event, options
         event.save
-      else        
+      else
         Delayed::Job.enqueue CreateEventJob.new(user_id, options)
       end
     end
   end
 end
 
-class DeleteEventJob < Struct.new(:user_id, :title)
+class DeleteEventJob < EventJob
   def perform
-    if cal = get_calendar(user_id)
-      event = GCal4Ruby::Event.find(cal.service, title, {:calendar => cal.id}).first
+    if cal = get_calendar
+      event = GCal4Ruby::Event.find(cal.service, options[:title], {:calendar => cal.id}).first
       event.delete unless event.blank?
     end
   end
 end
 
 class CrmGoogleCalendarModelHooks < FatFreeCRM::Callback::Base
-  
   Task.class_eval do
     after_create  :create_gcalendar
     after_update  :update_gcalendar
     after_destroy :destroy_gcalendar
 
     require 'gcal4ruby'
-    
+
     #----------------------------------------------------------------------------
     def create_gcalendar
       if allowed?
         event = GCal4Ruby::Event.new(GCal4Ruby::Service.new, {:title => get_title})
         set_event(event)
-        Delayed::Job.enqueue CreateEventJob.new(user_id, {
-          :title => event.title,
-          :content => event.content || '',
-          :attendees => event.attendees,
-          :start_time => event.start_time,
-          :end_time => event.end_time,
-          :all_day => event.all_day,
-          :reminder => event.reminder
-        })
+        Delayed::Job.enqueue CreateEventJob.new(user_id, get_event_options(event))
       end
-    rescue TaskNotAllowedError
-      logging.warn 'Task of bucket: #{bucket} not allowed for calendar.'
-    end
-    
-    def allowed?
-      !Regexp.new('^(due_later|due_asap)').match(bucket)
-    end
-    
-    def set_event(event)
-
-      if assigned_to
-        attendee = User.find(assigned_to)
-        event.attendees = [{ :name => attendee.full_name, :email => attendee.email }] if attendee
-      end
-      
-      event.content = background_info unless background_info.blank?
-      
-      case bucket
-      when "overdue"
-        if due_at
-          event.start_time = due_at
-          event.end_time = get_event_end
-        else
-          event.end_time = event.start_time = Time.zone.now.midnight.yesterday
-          event.all_day = true
-        end
-      when "due_today"
-        event.end_time = event.start_time = Time.zone.now.midnight
-        event.all_day = true
-      when "due_tomorrow"
-        event.end_time = event.start_time = Time.zone.now.midnight.tomorrow
-        event.all_day = true
-      when "due_this_week"
-        event.end_time = event.start_time = Time.zone.now.end_of_week - 2.day
-        event.all_day = true
-      when "due_next_week"
-        event.end_time = event.start_time = Time.zone.now.next_week.end_of_week - 2.day
-        event.all_day = true
-      when "specific_time"
-        event.start_time = due_at
-        event.end_time = get_event_end
-      else # due_later or due_asap
-        raise TaskNotAllowedError
-      end
-      
-      # TODO: Put the uri of the task: event.where = request.request_uri
-      
-      event.reminder = [{ :minutes => "15", :method => 'email' }]
     end
 
     #----------------------------------------------------------------------------
@@ -136,48 +73,94 @@ class CrmGoogleCalendarModelHooks < FatFreeCRM::Callback::Base
       if allowed?
         event = GCal4Ruby::Event.new(GCal4Ruby::Service.new)
         set_event(event)
-        Delayed::Job.enqueue UpdateEventJob.new(user_id, get_title(name_was), {
-          :title => get_title,
-          :content => event.content,
-          :attendees => event.attendees,
-          :start_time => event.start_time,
-          :end_time => event.end_time,
-          :all_day => event.all_day,
-          :reminder => event.reminder
-        })
+        options = get_event_options(event)
+        options[:title] = get_title
+        Delayed::Job.enqueue UpdateEventJob.new(user_id, options, get_title(name_was))
       end
-    rescue TaskNotAllowedError
-      logging.warn 'Task of bucket: #{bucket} not allowed for calendar.'
     end
 
     #----------------------------------------------------------------------------
     def destroy_gcalendar
       if allowed?
-        Delayed::Job.enqueue DeleteEventJob.new(user_id, get_title)
+        Delayed::Job.enqueue DeleteEventJob.new(user_id, {:title => get_title})
       end
     end
-    
+
+    #----------------------------------------------------------------------------
+    def allowed?
+      !Regexp.new('^(due_later|due_asap)').match(bucket)
+    end
+
+    #----------------------------------------------------------------------------
+    def set_event(event)
+      if assigned_to
+        attendee = User.find(assigned_to)
+        event.attendees = [{ :name => attendee.full_name, :email => attendee.email }] if attendee
+      end
+
+      event.content = background_info unless background_info.blank?
+
+      event.all_day = true unless (bucket == 'overdue' and due_at) or bucket == 'specific_time'
+
+      event.start_time = case bucket
+      when 'overdue'
+        due_at || now.mindnight.yesterday
+      when 'due_today'
+        Time.zone.now.midnight
+      when 'due_tomorrow'
+        Time.zone.now.midnight.tomorrow
+      when 'due_this_week'
+        Time.zone.now.end_of_week - 2.day
+      when 'due_next_week'
+        Time.zone.now.next_week.end_of_week - 2.day
+      when 'specific_time'
+        due_at
+      end
+
+      event.end_time = case bucket
+      when 'overdue'
+        due_at ? get_event_end : event.start_time
+      when 'specific_time'
+        get_event_end
+      else
+        event.start_time
+      end
+
+      # TODO: Put the uri of the task: event.where = request.request_uri
+
+      event.reminder = [{ :minutes => "15", :method => 'email' }]
+    end
+
+    def get_event_options(event)
+      {
+        :title => event.title,
+        :content => event.content,
+        :attendees => event.attendees,
+        :start_time => event.start_time,
+        :end_time => event.end_time,
+        :all_day => event.all_day,
+        :reminder => event.reminder
+      }
+    end
+
     #----------------------------------------------------------------------------
     def get_title(title='')
       title = name if title.blank?
-      if asset_id.blank? 
+      if asset_id.blank?
         "crm - #{get_category} - #{title}"
       else
         "crm - #{get_category} - #{title} (#{asset_type}: #{asset_type == "Contact" ? asset.full_name : asset.name})"
-      end      
+      end
     end
- 
+
     #----------------------------------------------------------------------------
     def get_category
       category == "" ? "other" : category
     end
 
     #----------------------------------------------------------------------------
-    def get_event_end(due=nil)
-      due ||= due_at
-      Setting.task_calendar_with_time == true ? due + 3600 : due + 32400
-    end    
-    
+    def get_event_end
+      Setting.task_calendar_with_time == true ? due_at + 3600 : due_at + 32400
+    end
   end
-  
 end


### PR DESCRIPTION
Not sure if you're interested, but this dramatically speeds up the create, update, and delete actions of tasks. Where before two requests (get_calendar, and then put/post/delete request) were blocking, now delayed_job allows us to schedule that work for later.

I've had to copy a lot of data to a simple hash, since the serialization wasn't working as expected. Regardless, send me your comments on ruby-ness (I'm not native to Ruby) and anything else you might have.
